### PR TITLE
Fixed: publishing before parallel builds complete.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -155,8 +155,9 @@ if( $Initialize )
 $context = New-WhiskeyContext -Environment 'Dev' -ConfigurationPath $configPath
 
 $apiKeys = @{
-                'PowerShellGallery' = 'POWERSHELL_GALLERY_API_KEY'
-                'github.com' = 'GITHUB_ACCESS_TOKEN'
+                'PowerShellGallery' = 'POWERSHELL_GALLERY_API_KEY';
+                'github.com' = 'GITHUB_ACCESS_TOKEN';
+                'AppVeyor' = 'APPVEYOR_BEARER_TOKEN';
             }
 
 $apiKeys.Keys |


### PR DESCRIPTION
If I were to merge develop into master, we would publish to the Gallery and GitHub before both builds completed, so if the Linux build fails, we would still publish.